### PR TITLE
Map cropping

### DIFF
--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -118,8 +118,10 @@ export default class Map extends Component<Prop>{
     
         return(
             <div>
-                <div className="w-full h-full border max-w-3xl mx-auto" style={{aspectRatio: this.props.width / this.props.height}}>
-                    <ZoomableSVG>
+                <div className="w-full h-full border max-w-3xl mx-auto" 
+                    style={{aspectRatio: this.props.width / this.props.height}}>
+                    <ZoomableSVG width={this.props.width} height={this.props.height} 
+                        navStep={this.props.navStep} enableZoom={false}>
                         <svg ref={(mapRef: SVGSVGElement) => this.mapRef = mapRef}>
                             
                         </svg>

--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import ZoomableSVG from './ZoomableSVG';
 import { NavigationStep } from '../types/navigation/NavigationStep';
 import { round } from '../utils/Math';
+import { CentroidScale } from '../types/navigation/CentroidScale';
 
 type Prop = {
     layoutImage: string
@@ -10,6 +11,7 @@ type Prop = {
     width: number
     height: number
     navStep: NavigationStep
+    centroidCrop: CentroidScale
 }
 
 const dotRadiusRelative: String = "0.5%"
@@ -119,7 +121,7 @@ export default class Map extends Component<Prop>{
         return(
                 <div className="w-full h-2/5 border max-w-3xl mx-auto">
                     <ZoomableSVG width={this.props.width} height={this.props.height} 
-                        navStep={this.props.navStep} enableZoom={false}>
+                        centroidCrop={this.props.centroidCrop} enableZoom={false}>
                         <svg ref={(mapRef: SVGSVGElement) => this.mapRef = mapRef}>
                             
                         </svg>

--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -117,9 +117,7 @@ export default class Map extends Component<Prop>{
     render() {
     
         return(
-            <div>
-                <div className="w-full h-full border max-w-3xl mx-auto" 
-                    style={{aspectRatio: this.props.width / this.props.height}}>
+                <div className="w-full h-2/5 border max-w-3xl mx-auto">
                     <ZoomableSVG width={this.props.width} height={this.props.height} 
                         navStep={this.props.navStep} enableZoom={false}>
                         <svg ref={(mapRef: SVGSVGElement) => this.mapRef = mapRef}>
@@ -127,7 +125,6 @@ export default class Map extends Component<Prop>{
                         </svg>
                     </ZoomableSVG>
                 </div>
-            </div>
         )
     }
 

--- a/client/src/components/ZoomableSVG.tsx
+++ b/client/src/components/ZoomableSVG.tsx
@@ -1,18 +1,17 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { NavigationStep } from '../types/navigation/NavigationStep';
 import * as d3 from 'd3';
-import { MapCropperImpl } from '../logic/impl/MapCropperImpl';
+import { CentroidScale } from '../types/navigation/CentroidScale';
 
 type Prop = {
     children: any
     width: number
     height: number
-    navStep?: NavigationStep
+    centroidCrop: CentroidScale
     enableZoom?: boolean
 }
 
 
-export default function ZoomableSVG( { children, width, height, navStep, enableZoom }: Prop ){
+export default function ZoomableSVG( { children, width, height, centroidCrop, enableZoom }: Prop ){
 
 
     const svgRef = useRef()
@@ -36,8 +35,6 @@ export default function ZoomableSVG( { children, width, height, navStep, enableZ
         
     }
     else{
-        const mapCropper = new MapCropperImpl()
-        const centroidCrop = mapCropper.crop(navStep, width, height)
 
         width = centroidCrop.scaledWidth
         height = centroidCrop.scaledHeight

--- a/client/src/components/ZoomableSVG.tsx
+++ b/client/src/components/ZoomableSVG.tsx
@@ -50,7 +50,7 @@ export default function ZoomableSVG( { children, width, height, navStep, enableZ
     }
 
     return (
-        <svg ref={svgRef} viewBox={`0, 0, ${width}, ${height}`}>
+        <svg height="100%" width="100%" ref={svgRef} viewBox={`0, 0, ${width}, ${height}`}>
             <g transform={`translate(${x},${y})scale(${scale})`}>{children}</g>
         </svg>
     )

--- a/client/src/components/ZoomableSVG.tsx
+++ b/client/src/components/ZoomableSVG.tsx
@@ -1,27 +1,56 @@
-import React, { Component, useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
+import { NavigationStep } from '../types/navigation/NavigationStep';
 import * as d3 from 'd3';
+import { MapCropperImpl } from '../logic/impl/MapCropperImpl';
 
-export default function ZoomableSVG( { children } ){
+type Prop = {
+    children: any
+    width: number
+    height: number
+    navStep?: NavigationStep
+    enableZoom?: boolean
+}
+
+
+export default function ZoomableSVG( { children, width, height, navStep, enableZoom }: Prop ){
+
 
     const svgRef = useRef()
     const [scale, setScale] = useState(1)
     const [x, setX] = useState(0)
     const [y, setY] = useState(0)
 
-    useEffect(() => {
-        const zoom = d3.zoom().on("zoom", (event) => {
-            const { x, y, k } = event.transform
-            setScale(k)
-            setX(x)
-            setY(y)
-        })
 
-        d3.select(svgRef.current).call(zoom)
-    }, [])
+    if(enableZoom == true){
 
+        useEffect(() => {
+            const zoom = d3.zoom().on("zoom", (event) => {
+                const { x, y, k } = event.transform
+                setScale(k)
+                setX(x)
+                setY(y)
+            })
+
+            d3.select(svgRef.current).call(zoom)
+        }, [])
+        
+    }
+    else{
+        const mapCropper = new MapCropperImpl()
+        const centroidCrop = mapCropper.crop(navStep, width, height)
+
+        width = centroidCrop.scaledWidth
+        height = centroidCrop.scaledHeight
+
+        useEffect(() => {
+            setX(centroidCrop.translateX)
+            setY(centroidCrop.translateY)
+            setScale(centroidCrop.stepScale)
+        }, [centroidCrop])
+    }
 
     return (
-        <svg ref={svgRef} width="100%" height="100%">
+        <svg ref={svgRef} viewBox={`0, 0, ${width}, ${height}`}>
             <g transform={`translate(${x},${y})scale(${scale})`}>{children}</g>
         </svg>
     )

--- a/client/src/logic/impl/MapCropperImpl.ts
+++ b/client/src/logic/impl/MapCropperImpl.ts
@@ -1,0 +1,32 @@
+import { CentroidScale } from "../../types/navigation/CentroidScale";
+import { NavigationStep } from "../../types/navigation/NavigationStep";
+import { MapCropper } from "../interfaces/MapCropper";
+
+export class MapCropperImpl implements MapCropper{
+
+    crop(navigationStep: NavigationStep, width: number, height: number): CentroidScale {
+        
+        var sumX = 0
+        var sumY = 0
+        var stepScale = 3
+
+        var numOfNodes = navigationStep.nodes.length
+        var scaledWidth = width/stepScale
+        var scaledHeight = height/stepScale
+
+        navigationStep.nodes.forEach((node) => {
+            sumX += node.xCoordinate
+            sumY += node.yCoordinate           
+        })
+
+        var centroidX = sumX/numOfNodes
+        var centroidY = sumY/numOfNodes
+
+        var translateX = -1*centroidX*width/100 + width/stepScale - scaledWidth/2
+        var translateY = -1*centroidY*height/100 + height/stepScale - scaledHeight/2
+
+        return {translateX, translateY, stepScale, scaledWidth, scaledHeight}
+
+    }
+    
+}

--- a/client/src/logic/interfaces/MapCropper.ts
+++ b/client/src/logic/interfaces/MapCropper.ts
@@ -1,6 +1,6 @@
+import { CentroidScale } from "../../types/navigation/CentroidScale";
 import { NavigationStep } from "../../types/navigation/NavigationStep";
-import { Rectangle } from "../../types/navigation/Rectangle";
 
 export interface MapCropper {
-    crop(navigationStep: NavigationStep): Rectangle
+    crop(navigationStep: NavigationStep, width: number, height: number): CentroidScale
 }

--- a/client/src/pages/navigation.tsx
+++ b/client/src/pages/navigation.tsx
@@ -9,6 +9,7 @@ import { NavigationDirections } from "../types/navigation/NavigationDirections";
 import { SimpleMapNavigatorMockExample } from "../logic/mock/SimpleMapNavigatorMockExample";
 import { NavigationStep } from "../types/navigation/NavigationStep";
 import { useState } from "react";
+import { MapCropperImpl } from "../logic/impl/MapCropperImpl";
 
 
 
@@ -33,6 +34,10 @@ export default function Navigation(){
     const submapImage = submap.getSubmapImage(navSteps[currentStep].nodes[0].submapId)
     const numOfSteps = navSteps.length
 
+    const mapCropper = new MapCropperImpl()
+    const centroidCrop = mapCropper.crop(navSteps[currentStep], submapImage.width, submapImage.height)
+
+
 
     return(
         <>
@@ -45,7 +50,7 @@ export default function Navigation(){
                         currentDirection='/images/up-right.png' nextDirection='/images/up.png' />
                 </div>
                 <Map layoutImage={submapImage.path} enableDrawNodes width={submapImage.width} 
-                    height={submapImage.height} navStep={navSteps[currentStep]}/>  
+                    height={submapImage.height} navStep={navSteps[currentStep]} centroidCrop={centroidCrop}/>  
                 <div className="text-center justify-center flex mx-auto mb-4 inset-x-0 absolute bottom-0 my-12 h-1/7">
                     <Button text='Back' 
                         onClick={() => {

--- a/client/src/pages/navigation.tsx
+++ b/client/src/pages/navigation.tsx
@@ -37,14 +37,16 @@ export default function Navigation(){
     return(
         <>
             <div className="relative w-fill h-screen mx-auto my-0">
-                <Header text='Navigation' backPath='/' />
-                <div className="mx-auto max-w-sm">
+                <div className="h-1/8">
+                    <Header text='Navigation' backPath='/' />
+                </div>
+                <div className="mx-auto max-w-sm h-1/3">
                     <DirectionsCard currentText='Turn right' nextText='Go straight' 
                         currentDirection='/images/up-right.png' nextDirection='/images/up.png' />
                 </div>
                 <Map layoutImage={submapImage.path} enableDrawNodes width={submapImage.width} 
                     height={submapImage.height} navStep={navSteps[currentStep]}/>  
-                <div className="text-center justify-center flex mx-auto mb-4 inset-x-0 absolute bottom-0 my-12">
+                <div className="text-center justify-center flex mx-auto mb-4 inset-x-0 absolute bottom-0 my-12 h-1/7">
                     <Button text='Back' 
                         onClick={() => {
                             if(currentStep > 0) {

--- a/client/src/types/navigation/CentroidScale.ts
+++ b/client/src/types/navigation/CentroidScale.ts
@@ -1,0 +1,8 @@
+
+export type CentroidScale = {
+    translateX: number;
+    translateY: number;
+    stepScale: number;
+    scaledWidth: number;
+    scaledHeight: number;
+}


### PR DESCRIPTION
I implemented map cropping functionality by using ZoomableSVG component and MapCropping interface. For each navigation step, a centroid value of all nodes in certain step is calculated. By using that value and making some other calculations with it, the translation and scale transformations will display the part of the map on which current navigation step nodes are visible. For the scale variable I set its value to 3 (it can be changed, doesn't have to be 3, but I think it looks good like that). 

Also I made changes to navigation page layout. Each component on that page will take certain percentage of the screen.