### PR TITLE
Map cropping v2

### DIFF
--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -118,8 +118,10 @@ export default class Map extends Component<Prop>{
     
         return(
             <div>
-                <div className="w-full h-full border max-w-3xl mx-auto" style={{aspectRatio: this.props.width / this.props.height}}>
-                    <ZoomableSVG>
+                <div className="w-full h-full border max-w-3xl mx-auto" 
+                    style={{aspectRatio: this.props.width / this.props.height}}>
+                    <ZoomableSVG width={this.props.width} height={this.props.height} 
+                        navStep={this.props.navStep} enableZoom={false}>
                         <svg ref={(mapRef: SVGSVGElement) => this.mapRef = mapRef}>
                             
                         </svg>

--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import ZoomableSVG from './ZoomableSVG';
 import { NavigationStep } from '../types/navigation/NavigationStep';
 import { round } from '../utils/Math';
+import { CentroidScale } from '../types/navigation/CentroidScale';
 
 type Prop = {
     layoutImage: string
@@ -10,6 +11,7 @@ type Prop = {
     width: number
     height: number
     navStep: NavigationStep
+    centroidCrop: CentroidScale
 }
 
 const dotRadiusRelative: String = "0.5%"
@@ -119,7 +121,7 @@ export default class Map extends Component<Prop>{
         return(
                 <div className="w-full h-2/5 border max-w-3xl mx-auto">
                     <ZoomableSVG width={this.props.width} height={this.props.height} 
-                        navStep={this.props.navStep} enableZoom={false}>
+                        centroidCrop={this.props.centroidCrop} enableZoom={false}>
                         <svg ref={(mapRef: SVGSVGElement) => this.mapRef = mapRef}>
                             
                         </svg>

--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -117,9 +117,7 @@ export default class Map extends Component<Prop>{
     render() {
     
         return(
-            <div>
-                <div className="w-full h-full border max-w-3xl mx-auto" 
-                    style={{aspectRatio: this.props.width / this.props.height}}>
+                <div className="w-full h-2/5 border max-w-3xl mx-auto">
                     <ZoomableSVG width={this.props.width} height={this.props.height} 
                         navStep={this.props.navStep} enableZoom={false}>
                         <svg ref={(mapRef: SVGSVGElement) => this.mapRef = mapRef}>
@@ -127,7 +125,6 @@ export default class Map extends Component<Prop>{
                         </svg>
                     </ZoomableSVG>
                 </div>
-            </div>
         )
     }
 

--- a/client/src/components/ZoomableSVG.tsx
+++ b/client/src/components/ZoomableSVG.tsx
@@ -1,18 +1,17 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { NavigationStep } from '../types/navigation/NavigationStep';
 import * as d3 from 'd3';
-import { MapCropperImpl } from '../logic/impl/MapCropperImpl';
+import { CentroidScale } from '../types/navigation/CentroidScale';
 
 type Prop = {
     children: any
     width: number
     height: number
-    navStep?: NavigationStep
+    centroidCrop: CentroidScale
     enableZoom?: boolean
 }
 
 
-export default function ZoomableSVG( { children, width, height, navStep, enableZoom }: Prop ){
+export default function ZoomableSVG( { children, width, height, centroidCrop, enableZoom }: Prop ){
 
 
     const svgRef = useRef()
@@ -36,8 +35,6 @@ export default function ZoomableSVG( { children, width, height, navStep, enableZ
         
     }
     else{
-        const mapCropper = new MapCropperImpl()
-        const centroidCrop = mapCropper.crop(navStep, width, height)
 
         width = centroidCrop.scaledWidth
         height = centroidCrop.scaledHeight

--- a/client/src/components/ZoomableSVG.tsx
+++ b/client/src/components/ZoomableSVG.tsx
@@ -50,7 +50,7 @@ export default function ZoomableSVG( { children, width, height, navStep, enableZ
     }
 
     return (
-        <svg ref={svgRef} viewBox={`0, 0, ${width}, ${height}`}>
+        <svg height="100%" width="100%" ref={svgRef} viewBox={`0, 0, ${width}, ${height}`}>
             <g transform={`translate(${x},${y})scale(${scale})`}>{children}</g>
         </svg>
     )

--- a/client/src/components/ZoomableSVG.tsx
+++ b/client/src/components/ZoomableSVG.tsx
@@ -1,27 +1,56 @@
-import React, { Component, useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
+import { NavigationStep } from '../types/navigation/NavigationStep';
 import * as d3 from 'd3';
+import { MapCropperImpl } from '../logic/impl/MapCropperImpl';
 
-export default function ZoomableSVG( { children } ){
+type Prop = {
+    children: any
+    width: number
+    height: number
+    navStep?: NavigationStep
+    enableZoom?: boolean
+}
+
+
+export default function ZoomableSVG( { children, width, height, navStep, enableZoom }: Prop ){
+
 
     const svgRef = useRef()
     const [scale, setScale] = useState(1)
     const [x, setX] = useState(0)
     const [y, setY] = useState(0)
 
-    useEffect(() => {
-        const zoom = d3.zoom().on("zoom", (event) => {
-            const { x, y, k } = event.transform
-            setScale(k)
-            setX(x)
-            setY(y)
-        })
 
-        d3.select(svgRef.current).call(zoom)
-    }, [])
+    if(enableZoom == true){
 
+        useEffect(() => {
+            const zoom = d3.zoom().on("zoom", (event) => {
+                const { x, y, k } = event.transform
+                setScale(k)
+                setX(x)
+                setY(y)
+            })
+
+            d3.select(svgRef.current).call(zoom)
+        }, [])
+        
+    }
+    else{
+        const mapCropper = new MapCropperImpl()
+        const centroidCrop = mapCropper.crop(navStep, width, height)
+
+        width = centroidCrop.scaledWidth
+        height = centroidCrop.scaledHeight
+
+        useEffect(() => {
+            setX(centroidCrop.translateX)
+            setY(centroidCrop.translateY)
+            setScale(centroidCrop.stepScale)
+        }, [centroidCrop])
+    }
 
     return (
-        <svg ref={svgRef} width="100%" height="100%">
+        <svg ref={svgRef} viewBox={`0, 0, ${width}, ${height}`}>
             <g transform={`translate(${x},${y})scale(${scale})`}>{children}</g>
         </svg>
     )

--- a/client/src/logic/impl/MapCropperImpl.ts
+++ b/client/src/logic/impl/MapCropperImpl.ts
@@ -1,0 +1,32 @@
+import { CentroidScale } from "../../types/navigation/CentroidScale";
+import { NavigationStep } from "../../types/navigation/NavigationStep";
+import { MapCropper } from "../interfaces/MapCropper";
+
+export class MapCropperImpl implements MapCropper{
+
+    crop(navigationStep: NavigationStep, width: number, height: number): CentroidScale {
+        
+        var sumX = 0
+        var sumY = 0
+        var stepScale = 3
+
+        var numOfNodes = navigationStep.nodes.length
+        var scaledWidth = width/stepScale
+        var scaledHeight = height/stepScale
+
+        navigationStep.nodes.forEach((node) => {
+            sumX += node.xCoordinate
+            sumY += node.yCoordinate           
+        })
+
+        var centroidX = sumX/numOfNodes
+        var centroidY = sumY/numOfNodes
+
+        var translateX = -1*centroidX*width/100 + width/stepScale - scaledWidth/2
+        var translateY = -1*centroidY*height/100 + height/stepScale - scaledHeight/2
+
+        return {translateX, translateY, stepScale, scaledWidth, scaledHeight}
+
+    }
+    
+}

--- a/client/src/logic/impl/MapCropperImpl.ts
+++ b/client/src/logic/impl/MapCropperImpl.ts
@@ -1,32 +1,30 @@
 import { CentroidScale } from "../../types/navigation/CentroidScale";
 import { NavigationStep } from "../../types/navigation/NavigationStep";
 import { MapCropper } from "../interfaces/MapCropper";
+import { getNodeBounds } from "./graph/Utils";
 
 export class MapCropperImpl implements MapCropper{
 
     crop(navigationStep: NavigationStep, width: number, height: number): CentroidScale {
-        
-        var sumX = 0
-        var sumY = 0
-        var stepScale = 3
 
-        var numOfNodes = navigationStep.nodes.length
-        var scaledWidth = width/stepScale
-        var scaledHeight = height/stepScale
+        const {minX, minY, maxX, maxY} = getNodeBounds(navigationStep.nodes);
+        const centroidX = minX + (maxX - minX)/2;
+        const centroidY = minY + (maxY - minY)/2;
 
-        navigationStep.nodes.forEach((node) => {
-            sumX += node.xCoordinate
-            sumY += node.yCoordinate           
-        })
+        const stepScale = this.getStepScale(maxX - minX, maxY - minY);
 
-        var centroidX = sumX/numOfNodes
-        var centroidY = sumY/numOfNodes
+        const scaledWidth = width/stepScale;
+        const scaledHeight = height/stepScale;
 
-        var translateX = -1*centroidX*width/100 + width/stepScale - scaledWidth/2
-        var translateY = -1*centroidY*height/100 + height/stepScale - scaledHeight/2
+        const translateX = -1*centroidX*width/100 + scaledWidth/2;
+        const translateY = -1*centroidY*height/100 + scaledHeight/2;
 
-        return {translateX, translateY, stepScale, scaledWidth, scaledHeight}
-
+        return {translateX, translateY, stepScale, scaledWidth, scaledHeight};
     }
-    
+
+    private getStepScale(width: number, height: number): number {
+        const scaleWithoutMargins = Math.min(100/width, 100/height);
+        const marginfactor = 0.9;
+        return scaleWithoutMargins * marginfactor;
+    }
 }

--- a/client/src/logic/impl/graph/Utils.ts
+++ b/client/src/logic/impl/graph/Utils.ts
@@ -1,5 +1,6 @@
 import { Hallway } from "../../../data/Hallways";
 import { MapNode } from "../../../types/graph/MapNode";
+import { NavigationNode } from "../../../types/navigation/NavigationNode";
 import { Dot, Line } from "../../../utils/Geometry";
 
 export function nodeToDot(node: MapNode): Dot {
@@ -11,4 +12,20 @@ export function hallwayToLine(hallway: Hallway): Line {
         dot1: {x: hallway.x1, y: hallway.y1},
         dot2: {x: hallway.x2, y: hallway.y2},
     }
+}
+
+export function getNodeBounds(nodes: NavigationNode[]): {minX: number, minY: number, maxX: number, maxY: number} {
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+
+    nodes.forEach((node) => {
+        minX = Math.min(minX, node.xCoordinate);
+        minY = Math.min(minY, node.yCoordinate);
+        maxX = Math.max(maxX, node.xCoordinate);
+        maxY = Math.max(maxY, node.yCoordinate);
+    });
+
+    return {minX, minY, maxX, maxY};
 }

--- a/client/src/logic/impl/pathfinding/MapNavigatorImpl.ts
+++ b/client/src/logic/impl/pathfinding/MapNavigatorImpl.ts
@@ -6,6 +6,7 @@ import { MapNavigator } from "../../interfaces/MapNavigator";
 import { Graph } from "../../interfaces/Graph";
 import { findPathWithDijkstra } from "./findPathWithDijkstra";
 import { NavigationStep } from "../../../types/navigation/NavigationStep";
+import { getNodeBounds } from "../graph/Utils";
 
 export class MapNavigatorImpl implements MapNavigator {
     private graph: Graph;
@@ -29,24 +30,89 @@ export class MapNavigatorImpl implements MapNavigator {
     }
 
     private splitNavigationPathIntoSteps(path: NavigationNode[]): NavigationDirections {
+
+        const STEP_MAX_WIDTH = 30;
+        const STEP_MAX_HEIGHT = 30;
+
+        const usablePath = this.makeAllEdgesSmallEnough(path, STEP_MAX_WIDTH, STEP_MAX_HEIGHT);
+
         const steps: NavigationStep[] = [];
         let currentStepNodes: NavigationNode[] = [];
-        let previousNode: NavigationNode = null;
-        path.forEach(node => {
-            
-            if (previousNode !== null && node.submapId !== previousNode.submapId) {
-                steps.push(new NavigationStep(currentStepNodes))
-                currentStepNodes = []
-            }
-            currentStepNodes.push(node);
+        let previousNode: NavigationNode | null = null;
+        usablePath.forEach(node => {
+            const nextStep = [...currentStepNodes, node];
 
-            previousNode = node
+            if (previousNode == null) {
+                currentStepNodes = nextStep;
+            } else if (previousNode.submapId != node.submapId) {
+                steps.push(new NavigationStep(currentStepNodes))
+                currentStepNodes = [node]
+            } else if (!this.fitsInRectangle(nextStep, STEP_MAX_WIDTH, STEP_MAX_HEIGHT)) {
+                steps.push(new NavigationStep(currentStepNodes))
+                currentStepNodes = [previousNode, node]
+            } else {
+                currentStepNodes = nextStep;
+            }
+
+            previousNode = node;
         });
 
         if (currentStepNodes.length > 0) {
             steps.push(new NavigationStep(currentStepNodes))
         }
-        
+
         return new NavigationDirections(steps);
     }
+
+    private fitsInRectangle(stepNodes: NavigationNode[], maxWidth: number, maxHeight: number): boolean {
+        const {minX, minY, maxX, maxY} = getNodeBounds(stepNodes);
+
+        const stepWidth = maxX - minX;
+        const stepHeight = maxY - minY;
+        
+        return stepWidth <= maxWidth && stepHeight <= maxHeight;
+    }
+
+    private makeAllEdgesSmallEnough(pathNodes: NavigationNode[], maxWidth: number, maxHeight: number): NavigationNode[] {
+
+        if (pathNodes.length == 0) {
+            return [];
+        }
+
+        const result: NavigationNode[] = [];
+        let currentNode = pathNodes[0];
+        let nextNodeIndex: number = 1;
+    
+        let nextNode: NavigationNode = currentNode;
+
+        while (nextNodeIndex < pathNodes.length) {
+            nextNode = pathNodes[nextNodeIndex];
+
+            const edgeWidth = nextNode.xCoordinate - currentNode.xCoordinate;
+            const edgeHeight = nextNode.yCoordinate - currentNode.yCoordinate;
+
+            result.push(currentNode);
+
+            if (Math.abs(edgeWidth) <= maxWidth && Math.abs(edgeHeight) <= maxHeight) {
+                currentNode = nextNode;
+                nextNodeIndex++;
+            } else {
+                const ratio = Math.min(maxWidth / Math.abs(edgeWidth), maxHeight / Math.abs(edgeHeight));
+                const segmentDx = edgeWidth * ratio;
+                const segmentDy = edgeHeight * ratio;
+
+                const midNode = new NavigationNode(
+                    currentNode.submapId,
+                    currentNode.xCoordinate + segmentDx,
+                    currentNode.yCoordinate + segmentDy,
+                );
+                currentNode = midNode;
+            }
+        }
+
+        result.push(nextNode);
+    
+        return result;
+    }
+
 }

--- a/client/src/logic/interfaces/MapCropper.ts
+++ b/client/src/logic/interfaces/MapCropper.ts
@@ -1,6 +1,6 @@
+import { CentroidScale } from "../../types/navigation/CentroidScale";
 import { NavigationStep } from "../../types/navigation/NavigationStep";
-import { Rectangle } from "../../types/navigation/Rectangle";
 
 export interface MapCropper {
-    crop(navigationStep: NavigationStep): Rectangle
+    crop(navigationStep: NavigationStep, width: number, height: number): CentroidScale
 }

--- a/client/src/pages/graph.tsx
+++ b/client/src/pages/graph.tsx
@@ -6,6 +6,7 @@ import { createGraph } from "../logic/impl/graph/GraphFactory";
 import { GraphImpl } from "../logic/impl/graph/GraphImpl";
 import { Graph } from "../logic/interfaces/Graph";
 import { MapNode } from "../types/graph/MapNode";
+import { CentroidScale } from "../types/navigation/CentroidScale";
 import { NavigationNode } from '../types/navigation/NavigationNode';
 import { NavigationStep } from "../types/navigation/NavigationStep";
 
@@ -14,13 +15,21 @@ export default function GraphPage(){
         <div className="relative w-fill mx-auto my-0">
             {submaps.map(submap => {
                 const navSteps = navigationStepWithAllNodesFromTheSubmap(submap.id);
+                const fullScale: CentroidScale = {
+                    translateX: 0,
+                    translateY: 0,
+                    stepScale: 1,
+                    scaledWidth: submap.width,
+                    scaledHeight: submap.height,
+                }
                 return (
                     <div key={submap.id}>
                         <Map layoutImage={submap.path} 
                             enableDrawNodes={true}
                             width={submap.width}
                             height={submap.height}
-                            navStep={navSteps}/>
+                            navStep={navSteps}
+                            centroidCrop={fullScale}/>
                         <Separator />
                     </div>
                 );

--- a/client/src/pages/navigation.tsx
+++ b/client/src/pages/navigation.tsx
@@ -56,8 +56,10 @@ export default function Navigation(){
     return(
         <>
             <div className="relative w-fill h-screen mx-auto my-0">
-                <Header text='Navigation' backPath='/' />
-                <div className="mx-auto max-w-sm">
+                <div className="h-1/8">
+                    <Header text='Navigation' backPath='/' />
+                </div>
+                <div className="mx-auto max-w-sm h-1/3">
                     <DirectionsCard currentText='Turn right' nextText='Go straight' 
                         currentDirection='/images/up-right.png' nextDirection='/images/up.png' />
                 </div>

--- a/client/src/pages/navigation.tsx
+++ b/client/src/pages/navigation.tsx
@@ -13,6 +13,9 @@ import { GraphImpl } from "../logic/impl/graph/GraphImpl";
 import { createGraph } from "../logic/impl/graph/GraphFactory";
 import { allGraphData } from "../data/AllGraphData";
 import { Submap } from "../types/Submap";
+import { MapCropperImpl } from "../logic/impl/MapCropperImpl";
+import { CentroidScale } from "../types/navigation/CentroidScale";
+
 
 
 export default function Navigation(){
@@ -44,12 +47,16 @@ export default function Navigation(){
     
     let currentStep: NavigationStep | undefined;
     let submapImage: Submap | undefined;
+    let centroidCrop: CentroidScale
     if (navSteps !== undefined && navSteps.length > 0) {
         currentStep = navSteps[currentStepIndex];
         submapImage = submap.getSubmapImage(currentStep.nodes[0].submapId);
+        const mapCropper = new MapCropperImpl()
+        centroidCrop = mapCropper.crop(currentStep, submapImage.width, submapImage.height)
     } else {
         currentStep = undefined;
         submapImage = undefined;
+        centroidCrop = undefined;
     }
 
 
@@ -64,12 +71,12 @@ export default function Navigation(){
                         currentDirection='/images/up-right.png' nextDirection='/images/up.png' />
                 </div>
                 {
-                    currentStep !== undefined && submapImage !== undefined ?
+                    currentStep !== undefined && submapImage !== undefined && centroidCrop !== undefined ?
                         <Map layoutImage={submapImage.path} width={submapImage.width} 
-                        height={submapImage.height} navStep={currentStep}/>
+                        height={submapImage.height} navStep={currentStep} centroidCrop={centroidCrop}/>
                         : <div>Loading...</div>
                 }
-                <div className="text-center justify-center flex mx-auto mb-4 inset-x-0 absolute bottom-0 my-12">
+                <div className="text-center justify-center flex mx-auto mb-4 inset-x-0 absolute bottom-0 my-12 h-1/7">
                     <Button text='Back' 
                         onClick={() => {
                             if(currentStepIndex > 0) {

--- a/client/src/types/navigation/CentroidScale.ts
+++ b/client/src/types/navigation/CentroidScale.ts
@@ -1,0 +1,8 @@
+
+export type CentroidScale = {
+    translateX: number;
+    translateY: number;
+    stepScale: number;
+    scaledWidth: number;
+    scaledHeight: number;
+}


### PR DESCRIPTION
This pull request continues the changes made in #51.

Changes:
- Rebased to the current main branch (and solved conflicts)
- I removed the fixed `stepScale` and added a logic that scales each step differently based on its nodes (but they will mostly be the same size, keep reading).
- I changed the calculation logic of "the centroid". The average was working poorly when e.g. we have three points - two to the right and one to the left. Centroid was much to the right point to the point the left one was getting off the screen. The new calculation just finds a rect of min/max coordinates and picks the middle as a centroid.
- MapNavigatorImpl (more precisely, splitNavigationPathIntoSteps function) ensures that each step can fit within defined bounds (max width and max height). It will try to maximize the number of nodes in each step, making most of the steps nearly equal to the max dimensions.

